### PR TITLE
Update to standardize API endpoints and simplify v1 API documentation

### DIFF
--- a/Auctions/Domain.fs
+++ b/Auctions/Domain.fs
@@ -514,7 +514,7 @@ type Command with
       create
       <!> jreq "at" (function PlaceBid (d,_)-> Some d | _ -> None)
       <*> jreq "bid" (function PlaceBid (_,a)-> Some a | _ -> None)
-    (tag "$type" "AddAuction" auctionCodec) <|> (tag "$type" "PlaceBid" bidCodec)
+    tag "$type" "AddAuction" auctionCodec <|> tag "$type" "PlaceBid" bidCodec
 
 type Event with
   static member JsonObjCodec =

--- a/Auctions/MapToRedis.fs
+++ b/Auctions/MapToRedis.fs
@@ -40,10 +40,9 @@ let timeAndAuctionCodec : ConcreteCodec<HashEntry list, HashEntry list, DateTime
   <*> rreqWith (tryParseUser, (string>>implicit)) "User" (snd >> Auction.user >> Some )
   <*> ropt "Open" (snd >> Auction.biddersAreOpen >> Some)
 let timeAndBidCodec : ConcreteCodec<HashEntry list, HashEntry list, DateTime * Bid, DateTime * Bid> =
-  fun auction amountValue amountCurrency at bidAt user -> (at, { auction=AuctionId auction; amount={value=amountValue; currency=Currency.ofValue amountCurrency}; user= user; at= Option.defaultValue at bidAt })
+  fun auction amountValue at bidAt user -> (at, { auction=AuctionId auction; amount=amountValue; user= user; at= Option.defaultValue at bidAt })
   <!> rreq "Auction" (snd >> Bid.auction >> AuctionId.unwrap >> Some)
-  <*> rreq "AmountValue" (snd >> Bid.amount >> Amount.value >> Some)
-  <*> rreq "AmountCurrency" (snd >> Bid.amount >> Amount.currency >> Currency.value >> Some)
+  <*> rreq "AmountValue" (snd >> Bid.amount >> Some)
   <*> rreqWith (tryParseDateTime,ofDateTime) "At" (fst >> Some)
   // since BidAt is a new field, we don't want to require, we will use At if it's missing
   <*> roptWith (tryParseDateTime,ofDateTime) "BidAt" (snd >> Bid.at >> Some)

--- a/Auctions/Web.fs
+++ b/Auctions/Web.fs
@@ -63,12 +63,12 @@ module Paths =
   module Auction =
     /// /auctions
     let overview = "/auctions"
-    /// /auction
-    let register = "/auction"
-    /// /auction/INT
-    let details : Int64Path = "/auction/%d"
-    /// /auction/INT/bid
-    let placeBid : Int64Path = "/auction/%d/bid"
+    /// /auctions
+    let register = "/auctions"
+    /// /auctions/INT
+    let details : Int64Path = "/auctions/%d"
+    /// /auctions/INT/bid
+    let placeBid : Int64Path = "/auctions/%d/bid"
 
 (* Json API *)
 module OfJson=

--- a/Auctions/Web.fs
+++ b/Auctions/Web.fs
@@ -74,7 +74,7 @@ module Paths =
 module OfJson=
   type Typ = Type
   let bidReq (auctionId, user, at) (json:JsonValue) =
-    let create a = { user = user; amount=a; auction=auctionId; at = at }
+    let create a = { user = user; amount= a ; auction=auctionId; at = at }
     match FSharpData.Encoding json with
     | JObject o -> create <!> (o .@ "amount")
     | x -> Decode.Fail.objExpected x
@@ -83,7 +83,7 @@ module OfJson=
     let create id startsAt title endsAt (currency:string option) (typ:string option) (``open``:bool option)
       =
         let currency= currency |> Option.bind Currency.tryParse |> Option.defaultValue Currency.VAC
-        let defaultTyp = TimedAscending { reservePrice = Amount.zero currency; minRaise = Amount.zero currency;
+        let defaultTyp = TimedAscending { reservePrice = AmountValue.zero; minRaise = AmountValue.zero;
           timeFrame =TimeSpan.FromSeconds(0.0) }
         let typ = typ |> Option.bind Typ.TryParse
                       |> Option.defaultValue defaultTyp

--- a/README.md
+++ b/README.md
@@ -115,16 +115,16 @@ AUCTIONS_TOKEN_BUYER=`echo '{"sub":"a2", "name":"Buyer", "u_typ":"0"}' | base64`
 ### Endpoints
 
 - `GET /auctions` - List all auctions
-- `GET /auction/:id` - Get auction details, including bids and winner information if available
-- `POST /auction` - Create a new auction
-- `POST /auction/:id/bid` - Place a bid on an auction
+- `GET /auctions/:id` - Get auction details, including bids and winner information if available
+- `POST /auctions` - Create a new auction
+- `POST /auctions/:id/bid` - Place a bid on an auction
 
 ### Example Requests
 
 #### Create an auction
 
 ```bash
-curl -X POST http://localhost:8083/auction \
+curl -X POST http://localhost:8083/auctions \
   -H "Content-Type: application/json" \
   -H "x-jwt-payload: $AUCTIONS_TOKEN_SELLER" \
   -d '{
@@ -139,7 +139,7 @@ curl -X POST http://localhost:8083/auction \
 #### Place a bid
 
 ```bash
-curl -X POST http://localhost:8083/auction/1/bid \
+curl -X POST http://localhost:8083/auctions/1/bid \
   -H "Content-Type: application/json" \
   -H "x-jwt-payload: $AUCTIONS_TOKEN_BUYER" \
   -d '{

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ curl -X POST http://localhost:8083/auction/1/bid \
   -H "Content-Type: application/json" \
   -H "x-jwt-payload: $AUCTIONS_TOKEN_BUYER" \
   -d '{
-    "amount": "VAC10"
+    "amount": 10
   }'
 ```
 

--- a/Tests/ActorTests.fs
+++ b/Tests/ActorTests.fs
@@ -21,8 +21,8 @@ module ``Auction agent tests`` =
                   user = seller
                   currency=Currency.VAC
                   typ=TimedAscending { // let's start out with english auctions
-                    reservePrice=parse "VAC0"
-                    minRaise =parse "VAC0"
+                    reservePrice=parse "0"
+                    minRaise =parse "0"
                     timeFrame = TimeSpan.FromSeconds(0.0)
                   }
                   openBidders = false
@@ -33,7 +33,7 @@ module ``Auction agent tests`` =
   let emptyHandler= ignore
   let validBid = { auction =auctionId
                    user=buyer
-                   amount =parse "VAC10"
+                   amount =parse "10"
                    at = DateTime(2008,12,1)
                  }
   [<Fact>]
@@ -49,7 +49,7 @@ module ``Auction agent tests`` =
     t <- auction.expiry.AddDays(1.5)
     //Async.RunSynchronously(d.WakeUp())
     let maybeAuctionAndBids = Async.RunSynchronously( d.GetAuction auction.id )
-    maybeAuctionAndBids |> should equal (Some (auction, [validBid], (Some (validBid.amount, buyer))))
+    maybeAuctionAndBids |> should equal (Some (auction, [validBid], (Some ({ value = validBid.amount; currency = auction.currency }, buyer))))
 
   [<Fact>]
   let ``try to create auction in the past``() =

--- a/Tests/ApiSpec.fs
+++ b/Tests/ApiSpec.fs
@@ -40,7 +40,7 @@ let ``create auction 1``() =
   //
   let statusCode,res =
         (runWebPart (app()))
-        |> reqWithAuth HttpMethod.POST "/auction" (Some data) seller1
+        |> reqWithAuth HttpMethod.POST "/auctions" (Some data) seller1
   Assert.Equal (HttpStatusCode.OK, statusCode)
   assertStrJsonEqual ("""{
       "$type": "AuctionAdded",
@@ -70,7 +70,7 @@ let ``create auction 2``() =
   use data = new StringContent(secondAuctionRequest)
   let statusCode,res =
         (runWebPart (app()))
-        |> reqWithAuth HttpMethod.POST "/auction" (Some data) seller1
+        |> reqWithAuth HttpMethod.POST "/auctions" (Some data) seller1
   Assert.Equal (HttpStatusCode.OK, statusCode)
   assertStrJsonEqual ("""{
       "$type": "AuctionAdded",
@@ -92,12 +92,12 @@ let ``Place bid as buyer on auction 1``() =
   let app = app()
   use auctionReq = new StringContent(firstAuctionRequest)
   (runWebPart app)
-  |> reqWithAuth HttpMethod.POST "/auction" (Some auctionReq) seller1 |> ignore
+  |> reqWithAuth HttpMethod.POST "/auctions" (Some auctionReq) seller1 |> ignore
 
-  use bidReq = new StringContent("""{ "auction":"1","amount":11 }""")
+  use bidReq = new StringContent """{ "amount":11 }"""
   let statusCode,res =
         (runWebPart app)
-        |> reqWithAuth HttpMethod.POST "/auction/1/bid" (Some bidReq) buyer1
+        |> reqWithAuth HttpMethod.POST "/auctions/1/bid" (Some bidReq) buyer1
 
   Assert.Equal (HttpStatusCode.OK, statusCode)
   assertStrJsonEqual ("""{
@@ -116,11 +116,11 @@ let ``Place bid as buyer on auction 2``() =
   let app = app()
   use auctionReq = new StringContent(secondAuctionRequest)
   (runWebPart app)
-  |> reqWithAuth HttpMethod.POST "/auction" (Some auctionReq) seller1 |> ignore
-  use bidReq = new StringContent("""{ "amount":11 }""")
+  |> reqWithAuth HttpMethod.POST "/auctions" (Some auctionReq) seller1 |> ignore
+  use bidReq = new StringContent """{ "amount":11 }"""
   let statusCode,res =
         (runWebPart app)
-        |> reqWithAuth HttpMethod.POST "/auction/2/bid" (Some bidReq) buyer1
+        |> reqWithAuth HttpMethod.POST "/auctions/2/bid" (Some bidReq) buyer1
   Assert.Equal (HttpStatusCode.OK, statusCode)
   assertStrJsonEqual ("""{
     "$type": "BidAccepted",
@@ -138,11 +138,11 @@ let ``Place bid as seller on auction 1``() =
   let app = app()
   use auctionReq = new StringContent(firstAuctionRequest)
   (runWebPart app)
-  |> reqWithAuth HttpMethod.POST "/auction" (Some auctionReq) seller1 |> ignore
-  use bidReq = new StringContent("""{ "amount":11 }""")
+  |> reqWithAuth HttpMethod.POST "/auctions" (Some auctionReq) seller1 |> ignore
+  use bidReq = new StringContent """{ "amount":11 }"""
   let statusCode,res =
         (runWebPart app)
-        |> reqWithAuth HttpMethod.POST "/auction/1/bid" (Some bidReq) seller1
+        |> reqWithAuth HttpMethod.POST "/auctions/1/bid" (Some bidReq) seller1
   Assert.Equal (HttpStatusCode.BadRequest, statusCode)
   assertStrJsonEqual ("""{
     "type": "SellerCannotPlaceBids",
@@ -155,14 +155,14 @@ let ``get auctions``() =
   let app = app()
   use auctionReq = new StringContent(firstAuctionRequest)
   (runWebPart app)
-  |> reqWithAuth HttpMethod.POST "/auction" (Some auctionReq) seller1 |> ignore
-  use bidReq = new StringContent("""{ "amount":11 }""")
+  |> reqWithAuth HttpMethod.POST "/auctions" (Some auctionReq) seller1 |> ignore
+  use bidReq = new StringContent """{ "amount":11 }"""
   (runWebPart app)
-  |> reqWithAuth HttpMethod.POST "/auction/1/bid" (Some bidReq) buyer1 |> ignore
+  |> reqWithAuth HttpMethod.POST "/auctions/1/bid" (Some bidReq) buyer1 |> ignore
 
   let statusCode,res =
         (runWebPart app)
-        |> reqWithAuth HttpMethod.GET "/auction/1" None seller1
+        |> reqWithAuth HttpMethod.GET "/auctions/1" None seller1
   Assert.Equal (HttpStatusCode.OK, statusCode)
   assertStrJsonEqual ("""{
     "id": 1,

--- a/Tests/ApiSpec.fs
+++ b/Tests/ApiSpec.fs
@@ -51,7 +51,7 @@ let ``create auction 1``() =
           "title": "Some auction",
           "expiry": "2022-09-18T10:00:00.000Z",
           "user": "BuyerOrSeller|a1|Test",
-          "type": "English|VAC0|VAC0|0",
+          "type": "English|0|0|0",
           "currency": "VAC",
           "open": true
       }
@@ -81,7 +81,7 @@ let ``create auction 2``() =
           "title": "Some auction",
           "expiry": "2022-12-18T10:00:00.000Z",
           "user": "BuyerOrSeller|a1|Test",
-          "type": "English|VAC0|VAC0|0",
+          "type": "English|0|0|0",
           "currency": "VAC",
           "open": false
       }
@@ -94,7 +94,7 @@ let ``Place bid as buyer on auction 1``() =
   (runWebPart app)
   |> reqWithAuth HttpMethod.POST "/auction" (Some auctionReq) seller1 |> ignore
 
-  use bidReq = new StringContent("""{ "auction":"1","amount":"VAC11" }""")
+  use bidReq = new StringContent("""{ "auction":"1","amount":11 }""")
   let statusCode,res =
         (runWebPart app)
         |> reqWithAuth HttpMethod.POST "/auction/1/bid" (Some bidReq) buyer1
@@ -106,7 +106,7 @@ let ``Place bid as buyer on auction 1``() =
     "bid": {
         "auction": 1,
         "user": "BuyerOrSeller|a2|Buyer",
-        "amount": "VAC11",
+        "amount": 11,
         "at": "2022-08-04T00:00:00.000Z"
     }
 }""", res)
@@ -117,7 +117,7 @@ let ``Place bid as buyer on auction 2``() =
   use auctionReq = new StringContent(secondAuctionRequest)
   (runWebPart app)
   |> reqWithAuth HttpMethod.POST "/auction" (Some auctionReq) seller1 |> ignore
-  use bidReq = new StringContent("""{ "amount":"VAC11" }""")
+  use bidReq = new StringContent("""{ "amount":11 }""")
   let statusCode,res =
         (runWebPart app)
         |> reqWithAuth HttpMethod.POST "/auction/2/bid" (Some bidReq) buyer1
@@ -128,7 +128,7 @@ let ``Place bid as buyer on auction 2``() =
     "bid": {
         "auction": 2,
         "user": "BuyerOrSeller|a2|Buyer",
-        "amount": "VAC11",
+        "amount": 11,
         "at": "2022-08-04T00:00:00.000Z"
     }
 }""", res)
@@ -139,7 +139,7 @@ let ``Place bid as seller on auction 1``() =
   use auctionReq = new StringContent(firstAuctionRequest)
   (runWebPart app)
   |> reqWithAuth HttpMethod.POST "/auction" (Some auctionReq) seller1 |> ignore
-  use bidReq = new StringContent("""{ "amount":"VAC11" }""")
+  use bidReq = new StringContent("""{ "amount":11 }""")
   let statusCode,res =
         (runWebPart app)
         |> reqWithAuth HttpMethod.POST "/auction/1/bid" (Some bidReq) seller1
@@ -156,7 +156,7 @@ let ``get auctions``() =
   use auctionReq = new StringContent(firstAuctionRequest)
   (runWebPart app)
   |> reqWithAuth HttpMethod.POST "/auction" (Some auctionReq) seller1 |> ignore
-  use bidReq = new StringContent("""{ "auction":"1","amount":"VAC11" }""")
+  use bidReq = new StringContent("""{ "amount":11 }""")
   (runWebPart app)
   |> reqWithAuth HttpMethod.POST "/auction/1/bid" (Some bidReq) buyer1 |> ignore
 
@@ -172,7 +172,7 @@ let ``get auctions``() =
     "currency": "VAC",
     "bids": [
         {
-            "amount": "VAC11",
+            "amount": 11,
             "bidder": "BuyerOrSeller|a2|Buyer"
         }
     ],

--- a/Tests/AuctionBidValidationTests.fs
+++ b/Tests/AuctionBidValidationTests.fs
@@ -8,7 +8,7 @@ open TestData
 module ``Auction Bid tests`` =
   let validBid = { auction =auctionId
                    user=buyer
-                   amount =parse "SEK10"
+                   amount =parse "10"
                    at = auction.startsAt.AddHours(1.0)
                  }
   let bidWithSameUser = { validBid with user=seller }

--- a/Tests/AuctionStateTests.fs
+++ b/Tests/AuctionStateTests.fs
@@ -9,8 +9,8 @@ open FSharpPlus
 module ``Auction state tests`` =
   open TestData
   let timedAscAuction = auctionOfTyp (TimedAscending { // let's start out with english auctions
-    reservePrice= parse "SEK0"
-    minRaise = parse "SEK0"
+    reservePrice= parse "0"
+    minRaise = parse "0"
     timeFrame = TimeSpan.FromSeconds(0.0)
   })
   let timedAscState= Auction.emptyState timedAscAuction

--- a/Tests/DomainSerialization.fs
+++ b/Tests/DomainSerialization.fs
@@ -11,13 +11,13 @@ open Fleece
 open Fleece.FSharpData
 
 let sampleJsonLines = """
-[{"$type":"AddAuction","at":"2020-05-17T08:05:54.943Z","auction":{"id":2,"startsAt":"2018-12-01T10:00:00.000Z","title":"Some auction","expiry":"2020-05-18T10:00:00.000Z","user":"BuyerOrSeller|a1|Test","type":"English|VAC0|VAC0|0","currency":"VAC","open": false}}]
-[{"$type":"PlaceBid","at":"2020-05-17T08:05:59.182Z","bid":{"auction":1,"user":"BuyerOrSeller|a2|Buyer","amount":"VAC11","at":"2020-05-17T08:05:59.171Z"}}]
-[{"$type":"PlaceBid","at":"2020-05-17T08:06:02.198Z","bid":{"auction":2,"user":"BuyerOrSeller|a2|Buyer","amount":"VAC11","at":"2020-05-17T08:06:02.197Z"}}]
-[{"$type":"PlaceBid","at":"2020-05-17T08:06:06.854Z","bid":{"auction":2,"user":"BuyerOrSeller|a1|Test","amount":"VAC11","at":"2020-05-17T08:06:06.854Z"}}]
-[{"$type":"AddAuction","at":"2020-05-17T08:06:37.128Z","auction":{"id":1,"startsAt":"2018-12-01T10:00:00.000Z","title":"Some auction","expiry":"2020-05-18T10:00:00.000Z","user":"BuyerOrSeller|a1|Test","type":"English|VAC0|VAC0|0","currency":"VAC","open": false}}]
-[{"$type":"PlaceBid","at":"2020-05-17T08:06:53.148Z","bid":{"auction":1,"user":"BuyerOrSeller|a2|Buyer","amount":"VAC11","at":"2020-05-17T08:06:53.147Z"}}]
-[{"$type":"PlaceBid","at":"2020-05-17T08:06:57.773Z","bid":{"auction":1,"user":"BuyerOrSeller|a1|Test","amount":"VAC11","at":"2020-05-17T08:06:57.773Z"}}]
+[{"$type":"AddAuction","at":"2020-05-17T08:05:54.943Z","auction":{"id":2,"startsAt":"2018-12-01T10:00:00.000Z","title":"Some auction","expiry":"2020-05-18T10:00:00.000Z","user":"BuyerOrSeller|a1|Test","type":"English|0|0|0","currency":"VAC","open": false}}]
+[{"$type":"PlaceBid","at":"2020-05-17T08:05:59.182Z","bid":{"auction":1,"user":"BuyerOrSeller|a2|Buyer","amount":11,"at":"2020-05-17T08:05:59.171Z"}}]
+[{"$type":"PlaceBid","at":"2020-05-17T08:06:02.198Z","bid":{"auction":2,"user":"BuyerOrSeller|a2|Buyer","amount":11,"at":"2020-05-17T08:06:02.197Z"}}]
+[{"$type":"PlaceBid","at":"2020-05-17T08:06:06.854Z","bid":{"auction":2,"user":"BuyerOrSeller|a1|Test","amount":11,"at":"2020-05-17T08:06:06.854Z"}}]
+[{"$type":"AddAuction","at":"2020-05-17T08:06:37.128Z","auction":{"id":1,"startsAt":"2018-12-01T10:00:00.000Z","title":"Some auction","expiry":"2020-05-18T10:00:00.000Z","user":"BuyerOrSeller|a1|Test","type":"English|0|0|0","currency":"VAC","open": false}}]
+[{"$type":"PlaceBid","at":"2020-05-17T08:06:53.148Z","bid":{"auction":1,"user":"BuyerOrSeller|a2|Buyer","amount":11,"at":"2020-05-17T08:06:53.147Z"}}]
+[{"$type":"PlaceBid","at":"2020-05-17T08:06:57.773Z","bid":{"auction":1,"user":"BuyerOrSeller|a1|Test","amount":11,"at":"2020-05-17T08:06:57.773Z"}}]
 """
 let parseCommands lines =
   let parseLine line=
@@ -46,7 +46,7 @@ module Json =
     let splitLines (s:string)=s.Split([|'\r';'\n'|], StringSplitOptions.RemoveEmptyEntries)
     splitLines sampleJsonLines |> Array.iter parseLine
 
-  let bidJson = """{"auction":1,"user":"BuyerOrSeller|a2|Buyer","amount":"VAC11","at":"2020-05-17T08:05:59.171Z"}"""
+  let bidJson = """{"auction":1,"user":"BuyerOrSeller|a2|Buyer","amount":11,"at":"2020-05-17T08:05:59.171Z"}"""
   [<Fact>]
   let ``Bid sample json can be deserialized correctly``() =
     let b : Bid ParseResult = ofJsonText bidJson
@@ -54,7 +54,7 @@ module Json =
     | Ok bid->
       Assert.Equal (AuctionId <| 1L, bid.auction)
       Assert.Equal (BuyerOrSeller (UserId "a2","Buyer"), bid.user)
-      Assert.Equal (Amount.Parse "VAC11", bid.amount)
+      Assert.Equal (11L, bid.amount)
       let expectedAt = DateTime.ParseExact ("2020-05-17T08:05:59.171Z", [| "yyyy-MM-ddTHH:mm:ss.fffZ"; |], null, DateTimeStyles.RoundtripKind)
       Assert.Equal (expectedAt, bid.at)
     | Error e -> failwithf $"Error %A{e}"
@@ -67,7 +67,7 @@ module Json =
       assertJsonEqual (JsonValue.Parse bidJson, j)
     | Error e -> failwithf $"Error %A{e}"
 
-  let auctionJson = """{"id":2,"startsAt":"2018-12-01T10:00:00.000Z","title":"Some auction","expiry":"2020-05-18T10:00:00.000Z","user":"BuyerOrSeller|a1|Test","type":"English|VAC0|VAC0|0","currency":"VAC","open": false}"""
+  let auctionJson = """{"id":2,"startsAt":"2018-12-01T10:00:00.000Z","title":"Some auction","expiry":"2020-05-18T10:00:00.000Z","user":"BuyerOrSeller|a1|Test","type":"English|0|0|0","currency":"VAC","open": false}"""
   [<Fact>]
   let ``Auction sample json can be deserialized correctly``() =
     let a : Auction ParseResult = ofJsonText auctionJson
@@ -79,7 +79,7 @@ module Json =
       Assert.Equal (expectedAt, auction.startsAt)
       Assert.Equal ("Some auction", auction.title)
       Assert.Equal (Currency.VAC, auction.currency)
-      Assert.Equal (Type.Parse "English|VAC0|VAC0|0", auction.typ)
+      Assert.Equal (Type.Parse "English|0|0|0", auction.typ)
     | Error e -> failwithf $"Error %A{e}"
   [<Fact>]
   let ``Auction sample json can be deserialized and serialized to the same json``() =

--- a/Tests/EnglishAuctionStateSpec.fs
+++ b/Tests/EnglishAuctionStateSpec.fs
@@ -6,8 +6,8 @@ open System
 open FSharpPlus
 open TestData
 let timedAscAuction = auctionOfTyp (TimedAscending { // let's start out with english auctions
-    reservePrice= parse "SEK0"
-    minRaise =parse "SEK0"
+    reservePrice= parse "0"
+    minRaise =parse "0"
     timeFrame = TimeSpan.FromSeconds(0.0)
   })
 let englishEmptyState = Auction.emptyState timedAscAuction

--- a/Tests/TestData.xml
+++ b/Tests/TestData.xml
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<Commands>
-</Commands>

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <Compile Include="TestsModule.fs" />
     <Compile Include="UserTests.fs" />
-    <Content Include="TestData.xml" />
     <Compile Include="AuctionStateSpecs.fs" />
     <Compile Include="VickreyAuctionStateSpec.fs" />
     <Compile Include="BlindAuctionStateSpec.fs" />

--- a/Tests/TestsModule.fs
+++ b/Tests/TestsModule.fs
@@ -32,7 +32,7 @@ module TestData =
   let bid =
       { auction = auctionId
         user = buyer
-        amount = sek 100L
+        amount = 100L
         at = DateTime(2016, 1, 2) }
 
   let buyer1 = BuyerOrSeller(UserId "x2", "Buyer")
@@ -40,12 +40,12 @@ module TestData =
 
   let bid1 = { auction =auctionId
                user=buyer1
-               amount =parse "SEK10"
+               amount =parse "10"
                at = startsAt.AddHours(1.0)
              }
   let bid2 = { auction =auctionId
                user=buyer2
-               amount =parse "SEK12"
+               amount =parse "12"
                at = startsAt.AddHours(2.0)
              }
 

--- a/Tests/WebTests.fs
+++ b/Tests/WebTests.fs
@@ -79,12 +79,12 @@ module ``JwtPayload deserialization spec``=
 
 open TestData
 module ``bid deserialization spec``=
-  let ``bid of 10 VAC`` = OfJson.bidReq (auctionId,buyer,endsAt) (JsonValue.Parse """{ "amount":"VAC10" }""")
+  let ``bid of 10`` = OfJson.bidReq (auctionId,buyer,endsAt) (JsonValue.Parse """{ "amount":10 }""")
 
   [<Fact>]
   let ``can parse bid request``() =
-    assertOkWithValue ({ user = buyer; amount={ value=10; currency=Currency.VAC }
-                         auction=auctionId; at = endsAt }, ``bid of 10 VAC``)
+    assertOkWithValue ({ user = buyer; amount=10
+                         auction=auctionId; at = endsAt }, ``bid of 10``)
 
 module ``auction deserialization spec``=
   let ``add first auction`` = OfJson.addAuctionReq seller (JsonValue.Parse """{ "id":1,"startsAt":"2016-01-01T00:00:00.000Z","endsAt":"2016-02-01T00:00:00.000Z","title":"First auction", "currency":"VAC" }""")
@@ -98,8 +98,8 @@ module ``auction deserialization spec``=
                          startsAt = startsAt; expiry = endsAt
                          currency = Currency.VAC
                          user = seller
-                         typ = TimedAscending { reservePrice = Amount.zero Currency.VAC
-                                                minRaise = Amount.zero Currency.VAC
+                         typ = TimedAscending { reservePrice = AmountValue.zero
+                                                minRaise = AmountValue.zero
                                                 timeFrame = TimeSpan.Zero }
                          openBidders = false }
         Assert.Equal(expected, auctionReq)


### PR DESCRIPTION
Update to standardize API endpoints and simplify v1 API documentation.

- Updated endpoints to consistently use the plural "/auctions" path
- Revised example curl commands to match updated endpoints and parameter types