### PR TITLE
Upgrade libraries 2025 12 11

### DIFF
--- a/App/Program.fs
+++ b/App/Program.fs
@@ -11,7 +11,7 @@ type DictEntry = System.Collections.DictionaryEntry
 
 type CmdArgs =
   { IP : System.Net.IPAddress
-    Port : Sockets.Port
+    Port : uint16
     Redis : string option
     Json : string option
     Event : bool

--- a/Auctions/Auctions.fsproj
+++ b/Auctions/Auctions.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Security.Cryptography.fs" />
@@ -18,8 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Fleece.FSharpData" Version="0.10.0" />
     <PackageReference Include="Suave" Version="2.5.6" />
-    <PackageReference Include="FSharpPlus" Version="1.3.2" />
+    <PackageReference Include="FSharpPlus" Version="1.8.0" />
     <PackageReference Include="FSharp.Codecs.Redis" Version="0.1.0" />
-    <PackageReference Update="FSharp.Core" Version="6.0.6" />
   </ItemGroup>
 </Project>

--- a/Auctions/Auctions.fsproj
+++ b/Auctions/Auctions.fsproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fleece.FSharpData" Version="0.10.0" />
-    <PackageReference Include="Suave" Version="2.5.6" />
+    <PackageReference Include="Suave" Version="3.2.0" />
     <PackageReference Include="FSharpPlus" Version="1.8.0" />
     <PackageReference Include="FSharp.Codecs.Redis" Version="0.1.0" />
   </ItemGroup>

--- a/Auctions/Environment.fs
+++ b/Auctions/Environment.fs
@@ -1,6 +1,6 @@
 module Auctions.Environment
 open System
-
+open System.Text.RegularExpressions
 
 type DictEntry = System.Collections.DictionaryEntry
 
@@ -9,7 +9,7 @@ module Env=
     Seq.cast<DictEntry>( Environment.GetEnvironmentVariables())
     |> Seq.map(fun kv-> (string kv.Key, string kv.Value) )
   let envArgs (prefix:string) (env:(string*string) seq) =
-    let mangle (str:string) = Regex.replace "_" "-" str
+    let mangle (str:string) = Regex.Replace(str, "-", "_")
     env
     |> Seq.filter( fun (key, value) -> key.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase)
                                        && not <| String.IsNullOrEmpty value)

--- a/Auctions/Environment.fs
+++ b/Auctions/Environment.fs
@@ -9,7 +9,7 @@ module Env=
     Seq.cast<DictEntry>( Environment.GetEnvironmentVariables())
     |> Seq.map(fun kv-> (string kv.Key, string kv.Value) )
   let envArgs (prefix:string) (env:(string*string) seq) =
-    let mangle (str:string) = Regex.Replace(str, "-", "_")
+    let mangle (str:string) = Regex.Replace(str, "_", "-")
     env
     |> Seq.filter( fun (key, value) -> key.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase)
                                        && not <| String.IsNullOrEmpty value)

--- a/Tests/AmountTests.fs
+++ b/Tests/AmountTests.fs
@@ -4,6 +4,7 @@ open Auctions.Domain
 
 open Xunit
 open FsCheck
+open FsCheck.FSharp
 
 module ``Amount tests`` =
   let amountMax = {value=12L; currency=Currency.VAC}
@@ -31,4 +32,4 @@ module ``Amount tests`` =
     let roundtrip orig =
       let parsed = orig |> string |> Amount.TryParse
       Some orig ?=? parsed
-    fsCheck (Prop.forAll Arb.amount roundtrip)
+    fsCheck (Prop.forAll Arbitrary.amount roundtrip)

--- a/Tests/DomainSerialization.fs
+++ b/Tests/DomainSerialization.fs
@@ -6,6 +6,7 @@ open Auctions.Domain
 
 open Xunit
 open FsCheck
+open FsCheck.FSharp
 open FsCheck.Xunit
 open Fleece
 open Fleece.FSharpData
@@ -107,10 +108,10 @@ module Json =
   let ``serialized Currency is the same as the input`` (u: Currency) = roundtrip u
   [<Fact>]
   let ``serialized Buyer or seller User is the same as the input``() =
-    fsCheck (Prop.forAll Arb.buyerOrSeller roundtrip)
+    fsCheck (Prop.forAll Arbitrary.buyerOrSeller roundtrip)
   [<Fact>]
   let ``serialized Support User is the same as the input``() =
-    fsCheck (Prop.forAll Arb.support roundtrip)
+    fsCheck (Prop.forAll Arbitrary.support roundtrip)
   [<Property>]
   let ``serialized AuctionId is the same as the input`` (u: AuctionId) = roundtrip u
   [<Property>]

--- a/Tests/EnvironmentTest.fs
+++ b/Tests/EnvironmentTest.fs
@@ -5,9 +5,9 @@ open Auctions.Environment
 module ``Environment tests`` =
   [<Fact>]
   let ``can parse``() =
-    let vars = [("AUCTIONS_IP","8081"); ("AUCTIONS_HOST","127.0.0.1")]
+    let vars = [("AUCTIONS_IP","8081"); ("AUCTIONS_HOST","127.0.0.1"); ("AUCTIONS_web_hook", "10.20.2.8/webhook-receive")]
     let envArgs = vars |> Env.envArgs "AUCTIONS_"
-    let expected = ["--ip";"8081"; "--host"; "127.0.0.1"]
+    let expected = ["--ip";"8081"; "--host"; "127.0.0.1"; "--web-hook"; "10.20.2.8/webhook-receive"]
     Assert.Equal<string> (expected, envArgs)
 
   [<Fact>]

--- a/Tests/Program.fs
+++ b/Tests/Program.fs
@@ -1,1 +1,0 @@
-﻿module Program = let [<EntryPoint>] main _ = 0

--- a/Tests/SuaveTesting.fs
+++ b/Tests/SuaveTesting.fs
@@ -1,0 +1,255 @@
+module Suave.Testing
+
+(** For testing suave applications easily
+
+Example:
+
+  open Suave
+  open Suave.Web
+  open Suave.Types
+  open Suave.Testing
+
+  open Expecto
+
+  let runWithConfig = runWith defaultConfig
+
+  testCase "parsing a large multipart form" <| fun _ ->
+
+    let res =
+      runWithConfig testMultipartForm
+      |> req HttpMethod.POST "/" (Some byteArrayContent)
+
+    Expect.equal  "Bob <bob@wishfulcoding.mailgun.org>" ""
+
+*)
+
+open System
+open System.Diagnostics
+open System.Threading
+open System.Net
+open System.Net.Http
+open System.Net.Http.Headers
+//open Expecto
+open Suave
+//open Suave.Logging
+//open Suave.Logging.Message
+open Suave.Http
+
+[<AutoOpen>]
+module ResponseData =
+  let responseHeaders (response : HttpResponseMessage) =
+    response.Headers
+
+  let contentHeaders (response : HttpResponseMessage) =
+    response.Content.Headers
+
+  let statusCode (response : HttpResponseMessage) =
+    response.StatusCode
+
+  let contentString (response : HttpResponseMessage) =
+    response.Content.ReadAsStringAsync().Result
+
+  let contentByteArray (response : HttpResponseMessage) =
+    response.Content.ReadAsByteArrayAsync().Result
+
+module Utilities =
+
+  /// Utility function for mapping from Suave.Types.HttpMethod to
+  /// System.Net.Http.HttpMethod.
+  let toHttpMethod = function
+    | HttpMethod.GET -> HttpMethod.Get
+    | HttpMethod.POST -> HttpMethod.Post
+    | HttpMethod.DELETE -> HttpMethod.Delete
+    | HttpMethod.PUT-> HttpMethod.Put
+    | HttpMethod.HEAD -> HttpMethod.Head
+    | HttpMethod.TRACE -> HttpMethod.Trace
+    | HttpMethod.OPTIONS -> HttpMethod.Options
+    | HttpMethod.PATCH -> failwithf "PATCH not a supported method in HttpClient"
+    | HttpMethod.CONNECT -> failwithf "CONNECT not a supported method in the unit tests"
+    | HttpMethod.OTHER x -> failwithf "%A not a supported method" x
+
+open Utilities
+open System.Threading.Tasks
+
+/// This test context is a holder for the runtime values of the web
+/// server of suave, as well as the cancellation token that is
+/// threaded throughout the web server and will shut down all
+/// concurrently running async operations.
+///
+/// When you are done with it, you should call `dispose_context` to
+/// cancel the token and dispose the server's runtime artifacts
+/// (like the listening socket etc).
+type SuaveTestCtx =
+  { cts         : CancellationTokenSource
+    suaveConfig : SuaveConfig
+    serverTask  : Task }
+
+/// Cancels the cancellation token source and disposes the server's
+/// resources.
+let disposeContext (ctx : SuaveTestCtx) =
+  ctx.cts.Cancel()
+  // Give the server sufficient time to shut down and release the socket
+  // This is important with async Task-based servers
+  try
+    if not (ctx.serverTask.Wait(TimeSpan.FromSeconds 2.0)) then
+      () // Timeout - server is taking too long to shut down
+  with
+    | :? System.AggregateException -> () // Expected when cancellation occurs
+    | :? System.Threading.Tasks.TaskCanceledException -> ()
+  // Small additional delay to ensure socket is fully released
+  Threading.Thread.Sleep(100)
+  ctx.cts.Dispose()
+
+/// Create a new test context from a factory that starts the web
+/// server, such as `web_server_async` from `Suave.Web`. Also pass
+/// in a `SuaveConfig` value and the web parts you'd like to test.
+///
+/// The factory needs to start two async's, one which this function
+/// can block on (listening) and another (server) which is the actual
+/// async value of the running server. The listening async value will
+/// be awaited inside this function but the server async value will
+/// be run on the thread pool.
+let runWithFactory factory config webParts : SuaveTestCtx =
+  let binding = config.bindings.Head
+  let baseUri = binding.ToString()
+  let cts = new CancellationTokenSource()
+
+  let config2 = { config with cancellationToken = cts.Token; bufferSize = 128; maxOps = 10 }
+
+  let listening, (server) = factory { config with cancellationToken = cts .Token(*; logger = Targets.create Warn [||]*) } webParts
+  listening |> Async.RunSynchronously |> ignore // wait for the server to start listening
+
+  { cts = cts
+    suaveConfig = config2
+    serverTask = server }
+
+/// Similar to run_with_factory, but uses the default suave factory.
+let runWith config webParts = runWithFactory startWebServerAsync config webParts
+
+/// Ensures the context is disposed after 'f ctx' is called.
+let withContext f ctx =
+  try
+    f ctx
+  finally disposeContext ctx
+
+/// Create a new HttpRequestMessage towards the endpoint
+let createRequest methd resource query data (endpoint : Uri) =
+  let uriBuilder   = UriBuilder endpoint
+  uriBuilder.Path  <- resource
+  uriBuilder.Query <- query
+
+  let request = new HttpRequestMessage(toHttpMethod methd, uriBuilder.Uri)
+  request.Headers.ConnectionClose <- Nullable(true)
+  data |> Option.iter (fun data -> request.Content <- data)
+  request
+
+/// Create a new disposable HttpClientHandler
+let createHandler decomp_method cookies =
+  let handler = new Net.Http.HttpClientHandler(AllowAutoRedirect = false)
+  handler.AutomaticDecompression <- decomp_method
+  cookies |> Option.iter (fun cookies -> handler.CookieContainer <- cookies)
+  handler
+
+let createClient handler =
+  new HttpClient(handler)
+
+/// Send the request with the client - returning the result of the request
+let send (client : HttpClient) (timeout : TimeSpan) (ctx : SuaveTestCtx) (request : HttpRequestMessage) =
+  //ctx.suaveConfig.logger.verbose (
+   // eventX "Send"
+    //>> setFieldValue "method" request.Method.Method
+   // >> setFieldValue "uri" request.RequestUri)
+
+  let send = client.SendAsync(request, HttpCompletionOption.ResponseContentRead, ctx.cts.Token)
+
+  let completed = send.Wait (int timeout.TotalMilliseconds, ctx.cts.Token)
+  if not completed && Debugger.IsAttached then Debugger.Break()
+  elif not completed then failwith (sprintf "should finish request in %fms" timeout.TotalMilliseconds)
+
+  send.Result
+
+let endpointUri (suaveConfig : SuaveConfig) =
+  Uri(suaveConfig.bindings.Head.ToString())
+
+/// This is the main function for the testing library; it lets you assert
+/// on the request/response values while ensuring deterministic
+/// disposal of suave.
+///
+/// Currently, it:
+///
+///  - doesn't automatically follow 301 FOUND redirects (nor 302, 307) to
+///    ensure you can assert on redirects.
+///  - only requests to the very first binding your web server has in use
+///  - only sets a HttpContent if you have given a value to the `data`
+///    parameter.
+///  - waits 5000 ms for a reply, then breaks into the debugger if you're
+///    attached, otherwise asserts a failure of the timeout
+///  - calls `f_result` with the HttpResponseMessage
+///
+let reqResp
+  (methd : HttpMethod)
+  (resource : string)
+  (query : string)
+  data
+  (cookies : CookieContainer option)
+  (decompMethod : DecompressionMethods)
+  (fRequest : HttpRequestMessage -> HttpRequestMessage)
+  fResult =
+
+  let defaultTimeout = TimeSpan.FromSeconds 10.
+
+  withContext <| fun ctx ->
+    use handler = createHandler decompMethod cookies
+    use client = createClient handler
+    use request = createRequest methd resource query data (endpointUri ctx.suaveConfig) |> fRequest
+    use result = request |> send client defaultTimeout ctx
+    fResult result
+
+let req methd resource data =
+  reqResp methd resource "" data None DecompressionMethods.None id contentString
+
+let reqQuery methd resource query =
+  reqResp methd resource query None None DecompressionMethods.None id contentString
+
+let reqBytes methd resource data =
+  reqResp methd resource "" data None DecompressionMethods.None id contentByteArray
+
+let reqGZip methd resource data =
+  reqResp methd resource "" data None DecompressionMethods.GZip id contentString
+
+let reqDeflate methd resource data =
+  reqResp methd resource "" data None DecompressionMethods.Deflate id contentString
+
+let reqGZipBytes methd resource data =
+  reqResp methd resource "" data None DecompressionMethods.GZip id contentByteArray
+
+let reqDeflateBytes methd resource data =
+  reqResp methd resource "" data None DecompressionMethods.Deflate id contentByteArray
+
+let reqHeaders methd resource data =
+  reqResp methd resource "" data None DecompressionMethods.None id responseHeaders
+
+let reqContentHeaders methd resource data =
+  reqResp methd resource "" data None DecompressionMethods.None id contentHeaders
+
+let reqStatusCode methd resource data =
+  reqResp methd resource "" data None DecompressionMethods.None id statusCode
+
+/// Test a request by looking at the cookies alone.
+let reqCookies methd resource data ctx =
+  let cookies = new CookieContainer()
+  reqResp
+    methd resource "" data
+    (Some cookies)
+    DecompressionMethods.None
+    id
+    contentString
+    ctx
+  |> ignore // places stuff in the cookie container
+  cookies
+
+/// Returns the cookie collection for the default binding.
+let reqCookies' methd resource data ctx =
+  reqCookies methd resource data ctx
+  |> fun cookies ->
+    cookies.GetCookies(endpointUri ctx.suaveConfig)

--- a/Tests/SuaveTesting.fs
+++ b/Tests/SuaveTesting.fs
@@ -1,6 +1,7 @@
 module Suave.Testing
 
-(** For testing suave applications easily
+(** From https://github.com/SuaveIO/suave/blob/master/src/Suave.Tests/Testing.fs
+For testing suave applications easily
 
 Example:
 

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -23,20 +23,16 @@
     <Compile Include="EnvironmentTest.fs" />
     <Compile Include="WebTests.fs" />
     <Compile Include="ApiSpec.fs" />
-    <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="2.16.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Suave.Testing" Version="2.2.1" />
-    <PackageReference Include="FsCheck.Xunit" Version="2.16.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="FsUnit.xUnit" Version="5.1.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="FsUnit.xUnit" Version="7.1.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Update="FSharp.Core" Version="6.0.6" />
   </ItemGroup>
 </Project>

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -26,7 +26,7 @@
     <Compile Include="ApiSpec.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FsCheck.Xunit" Version="2.16.5" />
+    <PackageReference Include="FsCheck.Xunit" Version="3.3.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="FsUnit.xUnit" Version="7.1.1" />

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -7,6 +7,7 @@
     <ProjectReference Include="..\Auctions\Auctions.fsproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SuaveTesting.fs" />
     <Compile Include="TestsModule.fs" />
     <Compile Include="UserTests.fs" />
     <Compile Include="AuctionStateSpecs.fs" />
@@ -27,7 +28,6 @@
   <ItemGroup>
     <PackageReference Include="FsCheck.Xunit" Version="2.16.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Suave.Testing" Version="2.2.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="FsUnit.xUnit" Version="7.1.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Tests/TestsModule.fs
+++ b/Tests/TestsModule.fs
@@ -4,6 +4,7 @@ open Auctions.Domain
 open System
 open FSharpPlus
 open FsCheck
+open FsCheck.FSharp
 open System.Text.RegularExpressions
 module TestData =
   let auctionId = AuctionId 1L
@@ -73,37 +74,37 @@ module Gen =
     let currency =
       Gen.elements (Seq.cast<CurrencyCode> (Enum.GetValues typeof<CurrencyCode>)) |> Gen.map Currency
 
-module Arb =
+module Arbitrary =
   let nonNullAndNotNewlineOrSpace =
-    Arb.from<string> |> Arb.filter String.isNotNewlineOrSpace
+    ArbMap.defaults |> ArbMap.arbitrary<string> |> Arb.filter String.isNotNewlineOrSpace
   let nonNullAndNotVerticalBarOrNewLineOrSpace =
-    Arb.from<string> |> Arb.filter String.isNotVerticalBarNewlineOrSpace
+    ArbMap.defaults |> ArbMap.arbitrary<string> |> Arb.filter String.isNotVerticalBarNewlineOrSpace
   /// Generate amounts with known currency codes and positive integers as values
   let amount =
-    let positiveInt = Arb.toGen Arb.from<PositiveInt>
+    let positiveInt = Arb.toGen (ArbMap.defaults |> ArbMap.arbitrary<PositiveInt>)
     let toAmount (c, PositiveInt i) = { value=int64 i;currency=c }
     let ofAmount { value=i;currency=c } = (c, PositiveInt (int i))
-    Arb.fromGenShrink (Gen.zip Gen.currency positiveInt, Arb.shrink) |> Arb.convert toAmount ofAmount
+    Arb.fromGenShrink (Gen.zip Gen.currency positiveInt, (ArbMap.defaults |> ArbMap.arbitrary<_> |> Arb.toShrink)) |> Arb.convert toAmount ofAmount
 
   /// Arbitrary buyer or sellers with restricted values for userId and usernames
   let buyerOrSeller =
     let filter (userId,username) = String.isNotVerticalBarNewlineOrSpace userId && String.isNotNewlineOrSpace username
     let toBuyerOrSeller (userId,username) = BuyerOrSeller (UserId userId,username)
     let ofBuyerOrSeller = function | BuyerOrSeller (UserId userId,username) -> userId,username
-    Arb.from<string*string>
+    ArbMap.defaults |> ArbMap.arbitrary<string*string>
     |> Arb.filter filter
     |> Arb.convert toBuyerOrSeller ofBuyerOrSeller
   /// Arbitrary support users with restricted values for userId
   let support =
     let toSupport userId = Support (UserId userId)
     let ofSupport = function | Support (UserId userId) -> userId
-    Arb.from<string>
+    ArbMap.defaults |> ArbMap.arbitrary<string>
     |> Arb.filter String.isNotVerticalBarNewlineOrSpace
     |> Arb.convert toSupport ofSupport
 
-let inline (?=?) left right = left = right |@ sprintf "%A = %A" left right
+let inline (?=?) left right = Prop.label (sprintf "%A = %A" left right) (left = right)
 
-let fsCheck x = Check.One({Config.QuickThrowOnFailure with Name = "";  }, x)
+let fsCheck x = Check.One(Config.QuickThrowOnFailure, x)
 module Json =
   open FSharp.Data
   let rec areJsonEqual (expected: JsonValue, actual: JsonValue)=

--- a/Tests/UserTests.fs
+++ b/Tests/UserTests.fs
@@ -3,6 +3,7 @@ open Auctions.Domain
 open System
 open Xunit
 open FsCheck
+open FsCheck.FSharp
 
 type ``Can parse user``() =
 
@@ -21,10 +22,10 @@ type ``Can parse user``() =
     let roundtrip orig =
       let parsed = orig |> string |> User.TryParse
       Some orig ?=? parsed
-    fsCheck (Prop.forAll Arb.support roundtrip)
+    fsCheck (Prop.forAll Arbitrary.support roundtrip)
   [<Fact>]
   member test.``Buyer or seller roundtrip``() =
     let roundtrip orig =
       let parsed = orig |> string |> User.TryParse
       Some orig ?=? parsed
-    fsCheck (Prop.forAll Arb.buyerOrSeller roundtrip)
+    fsCheck (Prop.forAll Arbitrary.buyerOrSeller roundtrip)


### PR DESCRIPTION
- Migration from FsCheck 2.x to 3.x API (replacing Arb.from with ArbMap.defaults |> ArbMap.arbitrary)
- Package updates: FsCheck.Xunit (2.16.5 → 3.3.2), Microsoft.NET.Test.Sdk (17.4.0 → 18.0.1), xunit (2.4.2 → 2.9.3)
- Conversion of async workflows to task-based patterns in JsonAppendToFile module
- Copy of https://github.com/SuaveIO/suave/blob/master/src/Suave.Tests/Testing.fs into source to replace deprecated Suave.Testing library in order to use upgraded version of Suave